### PR TITLE
Adiciona PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Descrição
+
+<!-- O que esse código muda? Por que escolhi essa abordagem? Aprendi algo que vale a pena compartilhar? -->
+
+## Issue relacionada
+
+<!-- Se você escrever "#Closes" seguido do número da issue do Github, ele fechará automaticamente a issue para você quando o PR for aprovado -->
+<!-- Se não houver issue relacionada, pode apagar esse tópico -->
+
+## Critérios de aceite
+
+<!-- Inclua os critérios de aceite presentes na descrição da sua issue -->
+
+## Tipo de mudança
+
+<!-- Coloque um `✓` para o checkbox correspondente: -->
+
+|     | Type                               |
+| --- | ---------------------------------- |
+|     | :bug: Correção de bug              |
+|  ✓  | :sparkles: Nova feature            |
+|     | :hammer: Refatoração               |
+|     | :100: Adição de testes             |
+|     | :link: Atualização de dependências |
+|     | :scroll: Documentação              |
+
+## Atualizações
+
+### Antes
+
+<!-- Se forem mudanças de IU, forneça capturas de tela -->
+
+
+### After
+
+<!-- Se forem mudanças de IU, forneça capturas de tela -->
+
+
+## Passos de teste / Critérios de QA
+
+<!-- Forneça as etapas que os outros membros do projeto precisam seguir para testar adequadamente suas adições -->
+


### PR DESCRIPTION
## Descrição

Estamos adicionando o PR template diretamente na branch master do projeto como uma tentativa de corrigir o problema que temos na branch development que não carrega o template corretamente.

## Issue relacionada

_Configurar PR template nos repos_

## Tipo de mudança

<!-- Coloque um `✓` para o checkbox correspondente: -->

|     | Type                               |
| --- | ---------------------------------- |
|     | :bug: Correção de bug              |
|     | :sparkles: Nova feature            |
|     | :hammer: Refatoração               |
|     | :100: Adição de testes             |
|     | :link: Atualização de dependências |
| ✓ | :scroll: Documentação              |


